### PR TITLE
Use var envs for the Geolite DB url and update interval

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: freegeoip -http :${PORT} -use-x-forwarded-for -public /app/cmd/freegeoip/public -quota-backend map -quota-max 10000
+web: freegeoip -http :${PORT} -use-x-forwarded-for -public /app/cmd/freegeoip/public -update $UPDATE_INTERVAL

--- a/db.go
+++ b/db.go
@@ -35,7 +35,7 @@ var (
 	defaultDB = filepath.Join(os.TempDir(), "freegeoip", "db.gz")
 
 	// MaxMindDB is the URL of the free MaxMind GeoLite2 database.
-	MaxMindDB = "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz"
+	MaxMindDB = os.Getenv("GEOLITE2_DB_URL")
 )
 
 // DB is the IP geolocation database.


### PR DESCRIPTION
We've update the URL that gets the database containing the geolocation
data.
We need this because the Freegeoip relies on the GeoLite2 databases to get the
location data and since they are updating the way they serve it we need
to comply with the new updates that went live on the 20191230. More info
check the Maxmind blog entry
https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/